### PR TITLE
feat: add -DBOARD_ROOT argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,5 @@ runs:
     - --no-sysbuild
     - --board 
     - ${{ inputs.board }}
-    
+    - --
+    - -DBOARD_ROOT=/github/workspace


### PR DESCRIPTION
This PR adds the -DBOARD_ROOT argument so the user can use a custom board in the CI

The custom board will be detected as long as it's inside the `boards/<architecture>` directory in the root of the git repository

I tried to use `$(pwd)` and `${{ github.workspace }}` as argument but both didn't work.
`$(pwd)` doesn't get evaluated and `${{ github.workspace }}`  failed with `Unrecognized named-value: 'github'. Located at position 1 within expression: github.workspace`. If you have any ideas on how to avoid using a magic value here i'm all ears but anyway, this works