### PR TITLE
fix west building

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@
 /bin/bash /workdir/zephyr-sdk-${ZEPHYR_TAG}/setup.sh -c
 
 # exec $@
-exec bash -c "$@"
+exec "$@"


### PR DESCRIPTION
This PR changes the entry point script to remove the "bash -c"

What i was seeing was that whenever I ran the action I would get the west help output indicating that the command was invalid. I think the bash -c wasn't able to correctly handle the arguments being split up onto multiple lines and was combining them into one line without leaving spaces in between the arguments. 

I have tested removing bash -c and it appears to work. 